### PR TITLE
Add Arc browser support with profile handling

### DIFF
--- a/.asimov/module.yaml
+++ b/.asimov/module.yaml
@@ -3,7 +3,7 @@
 name: chromium
 label: Chromium
 title: ASIMOV Chromium Module
-summary: Chromium (and Brave, Google Chrome) bookmark import.
+summary: Chromium (and Brave, Google Chrome, Arc) bookmark import.
 links:
   - https://github.com/asimov-modules/asimov-chromium-module
   - https://crates.io/crates/asimov-chromium-module
@@ -21,3 +21,4 @@ handles:
     - edge://bookmarks
     - opera://bookmarks
     - vivaldi://bookmarks
+    - arc://bookmarks

--- a/README.md
+++ b/README.md
@@ -64,6 +64,16 @@ asimov-chromium-cataloger edge://bookmarks
 asimov-chromium-cataloger edge://bookmarks/Profile\ 1
 ```
 
+#### Importing bookmarks from Arc
+
+```bash
+asimov-chromium-cataloger arc://bookmarks
+asimov-chromium-cataloger arc://bookmarks/Default
+asimov-chromium-cataloger arc://bookmarks/Profile1
+```
+
+**Note:** For Arc profiles with spaces, use the format without spaces (e.g., `Profile1` instead of `Profile 1`). The tool automatically formats them internally.
+
 ### Import of Bookmarks Files
 
 #### Parsing bookmarks files on macOS
@@ -73,6 +83,8 @@ asimov-chromium-reader < $HOME/Library/Application\ Support/Chromium/Profile\ 1/
 asimov-chromium-reader < $HOME/Library/Application\ Support/Google/Chrome/Profile\ 1/Bookmarks
 asimov-chromium-reader < $HOME/Library/Application\ Support/BraveSoftware/Brave-Browser/Default/Bookmarks
 asimov-chromium-reader < $HOME/Library/Application\ Support/Microsoft\ Edge/Profile\ 1/Bookmarks
+asimov-chromium-reader < $HOME/Library/Application\ Support/Google/Chrome/Profile\ 1/Bookmarks
+asimov-chromium-reader < $HOME/Library/Application\ Support/Arc/StorableSidebar.json
 ```
 
 #### Parsing bookmarks files on Linux
@@ -82,6 +94,7 @@ asimov-chromium-reader < $HOME/.config/chromium/Profile\ 1/Bookmarks
 asimov-chromium-reader < $HOME/.config/google-chrome/Profile\ 1/Bookmarks
 asimov-chromium-reader < $HOME/.config/BraveSoftware/Brave-Browser/Default/Bookmarks
 asimov-chromium-reader < $HOME/.config/microsoft-edge/Profile\ 1/Bookmarks
+asimov-chromium-reader < $HOME/.config/Arc/StorableSidebar.json
 ```
 
 #### Parsing bookmarks files on Windows
@@ -91,6 +104,7 @@ Get-Content "$env:LOCALAPPDATA\Chromium\User Data\Profile 1\Bookmarks" | asimov-
 Get-Content "$env:LOCALAPPDATA\Google\Chrome\User Data\Profile 1\Bookmarks" | asimov-chromium-reader
 Get-Content "$env:LOCALAPPDATA\BraveSoftware\Brave-Browser\User Data\Default\Bookmarks" | asimov-chromium-reader
 Get-Content "$env:LOCALAPPDATA\Microsoft\Edge\User Data\Profile 1\Bookmarks" | asimov-chromium-reader
+Get-Content "$env:LOCALAPPDATA\Arc\User Data\Default\StorableSidebar.json" | asimov-chromium-reader
 ```
 
 ## ⚙ Configuration

--- a/src/browsers.rs
+++ b/src/browsers.rs
@@ -4,7 +4,7 @@ use serde_json::Value;
 use std::path::{Path, PathBuf};
 use std::string::{String, ToString};
 use std::vec::Vec;
-use std::{boxed::Box, format, vec};
+use std::{format, vec};
 
 use crate::specialized;
 
@@ -250,25 +250,23 @@ pub fn fetch_bookmarks(url: &str) -> Result<Vec<Value>> {
 
         let profile_to_use = if let Some(profile_name) = profile.as_deref() {
             if profile_name == "Default" {
-                "Default"
+                "Default".to_string()
             } else if profile_name.starts_with("Profile") && !profile_name.contains(" ") {
                 let number = profile_name.strip_prefix("Profile").unwrap_or("");
                 if !number.is_empty() {
-                    let formatted_profile = format!("Profile {}", number);
-                    let profile_string = Box::leak(Box::new(formatted_profile));
-                    profile_string.as_str()
+                    format!("Profile {}", number)
                 } else {
-                    profile_name
+                    profile_name.to_string()
                 }
             } else {
-                profile_name
+                profile_name.to_string()
             }
         } else {
-            "Default"
+            "Default".to_string()
         };
 
-        if let Ok(path) = browser.bookmarks_path(Some(profile_to_use)) {
-            if let Ok(bookmarks) = read_bookmarks_file(&path, Some(profile_to_use)) {
+        if let Ok(path) = browser.bookmarks_path(Some(profile_to_use.as_str())) {
+            if let Ok(bookmarks) = read_bookmarks_file(&path, Some(profile_to_use.as_str())) {
                 return Ok(vec![bookmarks]);
             }
         }
@@ -293,7 +291,7 @@ pub fn fetch_bookmarks(url: &str) -> Result<Vec<Value>> {
     let mut outputs = Vec::new();
 
     for profile in profiles {
-        if let Ok(path) = browser.profile_path(Some(&profile)) {
+        if let Ok(path) = browser.bookmarks_path(Some(&profile)) {
             if let Ok(bookmarks) = read_bookmarks_file(&path, Some(&profile)) {
                 outputs.push(bookmarks);
             }

--- a/src/browsers.rs
+++ b/src/browsers.rs
@@ -232,7 +232,6 @@ pub fn fetch_bookmarks(url: &str) -> Result<Vec<Value>> {
     if browser.browser_type() == Some(Browser::Arc) {
         let profile: Option<String> = if url.starts_with("arc://bookmarks/") {
             let profile_part = url.strip_prefix("arc://bookmarks/").unwrap_or("");
-            print!("OLHA profile_part: {}", profile_part);
             if profile_part.is_empty() {
                 None
             } else {
@@ -248,7 +247,6 @@ pub fn fetch_bookmarks(url: &str) -> Result<Vec<Value>> {
                 .and_then(|suffix| suffix.strip_prefix('/').filter(|s| !s.is_empty()))
                 .map(|profile| profile.to_string())
         };
-        print!("OLHA profile novamente: {:?}", profile);
 
         let profile_to_use = if let Some(profile_name) = profile.as_deref() {
             if profile_name == "Default" {

--- a/src/browsers.rs
+++ b/src/browsers.rs
@@ -4,7 +4,7 @@ use serde_json::Value;
 use std::path::{Path, PathBuf};
 use std::string::{String, ToString};
 use std::vec::Vec;
-use std::{boxed::Box, format, print, vec};
+use std::{boxed::Box, format, vec};
 
 use crate::specialized;
 

--- a/src/browsers.rs
+++ b/src/browsers.rs
@@ -4,7 +4,9 @@ use serde_json::Value;
 use std::path::{Path, PathBuf};
 use std::string::{String, ToString};
 use std::vec::Vec;
-use std::{format, vec};
+use std::{boxed::Box, format, print, vec};
+
+use crate::specialized;
 
 /// Configuration for browser-specific user data paths.
 #[derive(Clone, Copy)]
@@ -22,9 +24,30 @@ pub struct BrowserConfig {
     paths: &'static UserDataPath,
 }
 
+/// Supported browsers enum
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Browser {
+    Chrome,
+    Brave,
+    Edge,
+    Chromium,
+    Arc,
+}
+
 impl BrowserConfig {
     pub fn name(&self) -> &str {
         self.name
+    }
+
+    fn browser_type(&self) -> Option<Browser> {
+        match self.name {
+            "chrome" => Some(Browser::Chrome),
+            "brave" => Some(Browser::Brave),
+            "edge" => Some(Browser::Edge),
+            "chromium" => Some(Browser::Chromium),
+            "arc" => Some(Browser::Arc),
+            _ => None,
+        }
     }
 
     pub fn profile_path(&self, profile_name: Option<&str>) -> Result<PathBuf> {
@@ -79,29 +102,76 @@ impl BrowserConfig {
     }
 
     pub fn bookmarks_path(&self, profile_name: Option<&str>) -> Result<PathBuf> {
-        self.profile_path(profile_name)
-            .map(|path| path.join("Bookmarks"))
+        match self.browser_type() {
+            Some(Browser::Arc) => {
+                // Arc sempre usa o StorableSidebar.json do diretório principal
+                // mas o profile_name é passado para convert_arc_to_bookmarks
+                self.platform_user_data_path()
+                    .map(|path| path.join("StorableSidebar.json"))
+            },
+            _ => self
+                .profile_path(profile_name)
+                .map(|path| path.join("Bookmarks")),
+        }
     }
 
     pub fn list_profiles(&self) -> Result<Vec<String>> {
-        let profile_path = self.profile_path(None)?;
-        let base_path = profile_path
-            .parent()
-            .ok_or_else(|| miette!("Failed to get parent directory"))?;
+        match self.browser_type() {
+            Some(Browser::Arc) => {
+                // Arc stores profiles in the User Data subdirectory
+                let mut base_path = self.platform_user_data_path()?;
+                base_path.push("User Data");
+                let mut profiles = Vec::new();
 
-        let mut profiles = Vec::new();
-        for entry in std::fs::read_dir(base_path).into_diagnostic()? {
-            let entry = entry.into_diagnostic()?;
-            if entry.file_type().into_diagnostic()?.is_dir() {
-                if let Some(name) = entry.file_name().to_str() {
-                    if matches!(name, "Default") || name.starts_with("Profile ") {
-                        profiles.push(name.to_string());
+                // Check if the User Data path exists
+                if base_path.is_dir() {
+                    for entry in std::fs::read_dir(&base_path).into_diagnostic()? {
+                        let entry = entry.into_diagnostic()?;
+                        if entry.file_type().into_diagnostic()?.is_dir() {
+                            if let Some(name) = entry.file_name().to_str() {
+                                // Arc profiles are typically named like "Profile 1", "Profile 2", etc.
+                                // or "Default" for the default profile
+                                if matches!(name, "Default") || name.starts_with("Profile ") {
+                                    profiles.push(name.to_string());
+                                }
+                            }
+                        }
                     }
                 }
-            }
+
+                // If no profiles found, return at least "Default"
+                if profiles.is_empty() {
+                    profiles.push("Default".to_string());
+                }
+
+                Ok(profiles)
+            },
+            _ => {
+                let profile_path = self.profile_path(None)?;
+                let base_path = profile_path
+                    .parent()
+                    .ok_or_else(|| miette!("Failed to get parent directory"))?;
+
+                let mut profiles = Vec::new();
+                for entry in std::fs::read_dir(base_path).into_diagnostic()? {
+                    let entry = entry.into_diagnostic()?;
+                    if entry.file_type().into_diagnostic()?.is_dir() {
+                        if let Some(name) = entry.file_name().to_str() {
+                            if matches!(name, "Default") || name.starts_with("Profile ") {
+                                profiles.push(name.to_string());
+                            }
+                        }
+                    }
+                }
+                Ok(profiles)
+            },
         }
-        Ok(profiles)
     }
+}
+
+/// Converts Arc's StorableSidebar.json format to standard Chromium bookmarks format
+fn convert_arc_to_bookmarks(arc_data: Value, profile: Option<&str>) -> Result<Value> {
+    specialized::arc::convert_arc_bookmarks_to_chromium(arc_data, profile)
 }
 
 static SUPPORTED_BROWSERS: phf::Map<&'static str, UserDataPath> = phf_map! {
@@ -129,6 +199,12 @@ static SUPPORTED_BROWSERS: phf::Map<&'static str, UserDataPath> = phf_map! {
         macos: "Library/Application Support/Chromium",
         windows: "Chromium/User Data",
     },
+    "arc" => UserDataPath {
+        url_prefix: "arc://bookmarks",
+        linux: ".config/Arc",
+        macos: "Library/Application Support/Arc",
+        windows: "Arc/User Data",
+    },
 };
 
 pub fn get_browser_from_url(url: &str) -> Option<BrowserConfig> {
@@ -152,6 +228,60 @@ pub fn fetch_bookmarks(url: &str) -> Result<Vec<Value>> {
         )
     })?;
 
+    // Arc browser special handling
+    if browser.browser_type() == Some(Browser::Arc) {
+        let profile: Option<String> = if url.starts_with("arc://bookmarks/") {
+            let profile_part = url.strip_prefix("arc://bookmarks/").unwrap_or("");
+            print!("OLHA profile_part: {}", profile_part);
+            if profile_part.is_empty() {
+                None
+            } else {
+                let decoded_profile = profile_part
+                    .replace("%20", " ")
+                    .replace("\\ ", " ")
+                    .replace("+", " ");
+
+                Some(decoded_profile)
+            }
+        } else {
+            url.strip_prefix(browser.paths.url_prefix)
+                .and_then(|suffix| suffix.strip_prefix('/').filter(|s| !s.is_empty()))
+                .map(|profile| profile.to_string())
+        };
+        print!("OLHA profile novamente: {:?}", profile);
+
+        let profile_to_use = if let Some(profile_name) = profile.as_deref() {
+            if profile_name == "Default" {
+                "Default"
+            } else if profile_name.starts_with("Profile") && !profile_name.contains(" ") {
+                let number = profile_name.strip_prefix("Profile").unwrap_or("");
+                if !number.is_empty() {
+                    let formatted_profile = format!("Profile {}", number);
+                    let profile_string = Box::leak(Box::new(formatted_profile));
+                    profile_string.as_str()
+                } else {
+                    profile_name
+                }
+            } else {
+                profile_name
+            }
+        } else {
+            "Default"
+        };
+
+        if let Ok(path) = browser.bookmarks_path(Some(profile_to_use)) {
+            if let Ok(bookmarks) = read_bookmarks_file(&path, Some(profile_to_use)) {
+                return Ok(vec![bookmarks]);
+            }
+        }
+
+        return Err(miette!(
+            "No valid bookmarks files found for browser: {}",
+            browser.name()
+        ));
+    }
+
+    // Other browsers
     let profiles: Vec<String> = url
         .strip_prefix(browser.paths.url_prefix)
         .and_then(|suffix| suffix.strip_prefix('/').filter(|s| !s.is_empty()))
@@ -165,8 +295,8 @@ pub fn fetch_bookmarks(url: &str) -> Result<Vec<Value>> {
     let mut outputs = Vec::new();
 
     for profile in profiles {
-        if let Ok(path) = browser.bookmarks_path(Some(&profile)) {
-            if let Ok(bookmarks) = read_bookmarks_file(&path) {
+        if let Ok(path) = browser.profile_path(Some(&profile)) {
+            if let Ok(bookmarks) = read_bookmarks_file(&path, Some(&profile)) {
                 outputs.push(bookmarks);
             }
         }
@@ -182,7 +312,7 @@ pub fn fetch_bookmarks(url: &str) -> Result<Vec<Value>> {
     Ok(outputs)
 }
 
-fn read_bookmarks_file(path: &Path) -> Result<Value> {
+fn read_bookmarks_file(path: &Path, profile: Option<&str>) -> Result<Value> {
     if !path.is_file() {
         return Err(miette!("Bookmarks file not found at {}", path.display()));
     }
@@ -191,7 +321,24 @@ fn read_bookmarks_file(path: &Path) -> Result<Value> {
         .into_diagnostic()
         .wrap_err_with(|| format!("Failed to read bookmarks at {}", path.display()))?;
 
-    serde_json::from_str(&input)
-        .into_diagnostic()
-        .wrap_err_with(|| format!("Failed to parse bookmarks JSON from {}", path.display()))
+    // Check if this is an Arc StorableSidebar.json file
+    if path.file_name().and_then(|n| n.to_str()) == Some("StorableSidebar.json") {
+        // Parse as Arc format and convert to standard bookmarks format
+        let arc_data: Value = serde_json::from_str(&input)
+            .into_diagnostic()
+            .wrap_err_with(|| {
+                format!(
+                    "Failed to parse Arc StorableSidebar.json from {}",
+                    path.display()
+                )
+            })?;
+
+        // Convert Arc format to standard bookmarks format
+        convert_arc_to_bookmarks(arc_data, profile)
+    } else {
+        // Standard Chromium bookmarks format
+        serde_json::from_str(&input)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("Failed to parse bookmarks JSON from {}", path.display()))
+    }
 }

--- a/src/cataloger/main.rs
+++ b/src/cataloger/main.rs
@@ -29,6 +29,7 @@ struct Options {
         Other("edge".into()),
         Other("opera".into()),
         Other("vivaldi".into()),
+        Other("arc".into()),
     ]))]
     url: Uri<'static>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,5 +9,6 @@ extern crate std;
 pub mod bookmarks;
 pub mod browsers;
 pub mod jq;
+pub mod specialized;
 
 pub use bookmarks::*;

--- a/src/reader/main.rs
+++ b/src/reader/main.rs
@@ -50,9 +50,14 @@ fn main() -> Result<SysexitsError, Box<dyn Error>> {
     // Convert Arc sidebar format to Chromium format
     if let Some(sidebar) = input.get("sidebar") {
         if let Some(_containers) = sidebar.get("containers") {
+            // Extract profile from input JSON or use "Default"
+            let profile = input.get("profile")
+                .and_then(|v| v.as_str().map(|s| s.to_string()))
+                .unwrap_or_else(|| "Default".to_string());
+            
             input = asimov_chromium_module::specialized::arc::convert_arc_bookmarks_to_chromium(
                 input,
-                Some("Default"),
+                Some(profile.as_str()),
             )?;
         }
     }

--- a/src/reader/main.rs
+++ b/src/reader/main.rs
@@ -51,10 +51,11 @@ fn main() -> Result<SysexitsError, Box<dyn Error>> {
     if let Some(sidebar) = input.get("sidebar") {
         if let Some(_containers) = sidebar.get("containers") {
             // Extract profile from input JSON or use "Default"
-            let profile = input.get("profile")
+            let profile = input
+                .get("profile")
                 .and_then(|v| v.as_str().map(|s| s.to_string()))
                 .unwrap_or_else(|| "Default".to_string());
-            
+
             input = asimov_chromium_module::specialized::arc::convert_arc_bookmarks_to_chromium(
                 input,
                 Some(profile.as_str()),

--- a/src/reader/main.rs
+++ b/src/reader/main.rs
@@ -45,7 +45,17 @@ fn main() -> Result<SysexitsError, Box<dyn Error>> {
     // Parse the input JSON:
     let mut buffer = String::new();
     std::io::stdin().lock().read_to_string(&mut buffer)?;
-    let input = serde_json::from_str(&buffer)?;
+    let mut input: serde_json::Value = serde_json::from_str(&buffer)?;
+
+    // Convert Arc sidebar format to Chromium format
+    if let Some(sidebar) = input.get("sidebar") {
+        if let Some(_containers) = sidebar.get("containers") {
+            input = asimov_chromium_module::specialized::arc::convert_arc_bookmarks_to_chromium(
+                input,
+                Some("Default"),
+            )?;
+        }
+    }
 
     // Transform JSON to JSON-LD:
     let transform = asimov_chromium_module::BookmarksTransform::new()?;

--- a/src/specialized/arc.rs
+++ b/src/specialized/arc.rs
@@ -1,0 +1,405 @@
+// This is free and unencumbered software released into the public domain.
+
+use miette::Result;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::format;
+use std::string::String;
+use std::string::ToString;
+use std::vec::Vec;
+
+/// Bookmark extracted from Arc's StorableSidebar.json
+#[derive(Debug)]
+pub struct ArcBookmark {
+    pub title: String,
+    pub url: String,
+    pub created_at: Option<f64>,
+}
+
+/// Finds the container with most saved bookmarks (fallback for old Arc versions)
+fn discover_pinned_container_id(arc_data: &Value) -> Option<String> {
+    let mut parent_id_counts: HashMap<String, usize> = HashMap::new();
+
+    if let Some(sidebar) = arc_data.get("sidebar") {
+        if let Some(containers) = sidebar.get("containers") {
+            if let Some(containers_array) = containers.as_array() {
+                for container in containers_array {
+                    if let Some(items) = container.get("items") {
+                        if let Some(items_array) = items.as_array() {
+                            for item in items_array {
+                                if let Some(parent_id) =
+                                    item.get("parentID").and_then(|pid| pid.as_str())
+                                {
+                                    if parent_id != "null" {
+                                        if let Some(data) = item.get("data") {
+                                            if let Some(tab) = data.get("tab") {
+                                                let has_saved_url = tab
+                                                    .get("savedURL")
+                                                    .and_then(|u| u.as_str())
+                                                    .map(|u| !u.is_empty())
+                                                    .unwrap_or(false);
+                                                let has_saved_title = tab
+                                                    .get("savedTitle")
+                                                    .and_then(|t| t.as_str())
+                                                    .map(|t| !t.is_empty() && t != "null")
+                                                    .unwrap_or(false);
+
+                                                if has_saved_url && has_saved_title {
+                                                    *parent_id_counts
+                                                        .entry(parent_id.to_string())
+                                                        .or_insert(0) += 1;
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    parent_id_counts
+        .into_iter()
+        .fold(None, |acc, (id, count)| match acc {
+            Some((acc_id, acc_count)) => {
+                if count > acc_count || (count == acc_count && id < acc_id) {
+                    Some((id, count))
+                } else {
+                    Some((acc_id, acc_count))
+                }
+            },
+            None => Some((id, count)),
+        })
+        .map(|(id, _)| id)
+}
+
+/// Maps profile names to their container IDs by analyzing container types
+fn discover_profile_containers(arc_data: &Value) -> HashMap<String, String> {
+    let mut profile_containers: HashMap<String, String> = HashMap::new();
+
+    if let Some(sidebar) = arc_data.get("sidebar") {
+        if let Some(containers) = sidebar.get("containers") {
+            if let Some(containers_array) = containers.as_array() {
+                for container in containers_array {
+                    if let Some(items) = container.get("items") {
+                        if let Some(items_array) = items.as_array() {
+                            for item in items_array {
+                                if let Some(data) = item.get("data") {
+                                    if let Some(item_container) = data.get("itemContainer") {
+                                        if let Some(container_type) =
+                                            item_container.get("containerType")
+                                        {
+                                            if let Some(top_apps) = container_type.get("topApps") {
+                                                if let Some(top_apps_data) = top_apps.get("_0") {
+                                                    if let Some(custom) =
+                                                        top_apps_data.get("custom")
+                                                    {
+                                                        if let Some(custom_data) = custom.get("_0")
+                                                        {
+                                                            if let Some(directory_basename) =
+                                                                custom_data.get("directoryBasename")
+                                                            {
+                                                                if let Some(profile_name) =
+                                                                    directory_basename.as_str()
+                                                                {
+                                                                    if let Some(id) = item
+                                                                        .get("id")
+                                                                        .and_then(|i| i.as_str())
+                                                                    {
+                                                                        profile_containers.insert(
+                                                                            profile_name
+                                                                                .to_string(),
+                                                                            id.to_string(),
+                                                                        );
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                    if top_apps_data.get("default").is_some() {
+                                                        if let Some(id) =
+                                                            item.get("id").and_then(|i| i.as_str())
+                                                        {
+                                                            profile_containers.insert(
+                                                                "Default".to_string(),
+                                                                id.to_string(),
+                                                            );
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    profile_containers
+}
+
+/// Extracts bookmarks for a specific profile or all profiles
+///
+/// Uses JSON-LD format when no profile specified (faster),
+/// falls back to sidebar format for profile filtering
+pub fn extract_arc_bookmarks_for_profile(
+    arc_data: &Value,
+    target_profile: Option<&str>,
+) -> Result<Vec<ArcBookmark>> {
+    if target_profile.is_some() {
+        return extract_arc_bookmarks_from_sidebar(arc_data, target_profile);
+    }
+
+    // Try new JSON-LD format first
+    if let Some(items) = arc_data.get("items") {
+        if let Some(items_array) = items.as_array() {
+            let mut bookmarks = Vec::new();
+            for item in items_array {
+                if let Some(bookmark) = extract_bookmark_from_jsonld_item(item) {
+                    bookmarks.push(bookmark);
+                }
+            }
+            return Ok(bookmarks);
+        }
+    }
+
+    extract_arc_bookmarks_from_sidebar(arc_data, target_profile)
+}
+
+/// Extracts bookmarks from sidebar structure with profile filtering
+fn extract_arc_bookmarks_from_sidebar(
+    arc_data: &Value,
+    target_profile: Option<&str>,
+) -> Result<Vec<ArcBookmark>> {
+    let mut bookmarks = Vec::new();
+    let profile_containers = discover_profile_containers(arc_data);
+
+    if profile_containers.is_empty() {
+        // Fallback to old logic
+        let pinned_container_id = discover_pinned_container_id(arc_data).ok_or_else(|| {
+            miette::miette!("Could not find any profile containers or pinned bookmarks in Arc data")
+        })?;
+
+        if let Some(sidebar) = arc_data.get("sidebar") {
+            if let Some(containers) = sidebar.get("containers") {
+                if let Some(containers_array) = containers.as_array() {
+                    for container in containers_array {
+                        if let Some(items) = container.get("items") {
+                            if let Some(items_array) = items.as_array() {
+                                for item in items_array {
+                                    if let Some(bookmark) =
+                                        extract_bookmark_from_item(item, &pinned_container_id)
+                                    {
+                                        bookmarks.push(bookmark);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    } else {
+        if let Some(target_profile_name) = target_profile {
+            if let Some(container_id) = profile_containers.get(target_profile_name) {
+                if let Some(sidebar) = arc_data.get("sidebar") {
+                    if let Some(containers) = sidebar.get("containers") {
+                        if let Some(containers_array) = containers.as_array() {
+                            for container in containers_array {
+                                if let Some(items) = container.get("items") {
+                                    if let Some(items_array) = items.as_array() {
+                                        for item in items_array {
+                                            if let Some(parent_id) =
+                                                item.get("parentID").and_then(|pid| pid.as_str())
+                                            {
+                                                if parent_id == container_id {
+                                                    if let Some(bookmark) =
+                                                        extract_bookmark_from_item_with_profile(
+                                                            item,
+                                                            container_id,
+                                                            target_profile_name,
+                                                        )
+                                                    {
+                                                        bookmarks.push(bookmark);
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            } else {
+                return Err(miette::miette!(
+                    "Profile '{}' not found. Available profiles: {}",
+                    target_profile_name,
+                    profile_containers
+                        .keys()
+                        .cloned()
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ));
+            }
+        } else {
+            // Extract from all profiles
+            for (profile_name, container_id) in profile_containers {
+                if let Some(sidebar) = arc_data.get("sidebar") {
+                    if let Some(containers) = sidebar.get("containers") {
+                        if let Some(containers_array) = containers.as_array() {
+                            for container in containers_array {
+                                if let Some(items) = container.get("items") {
+                                    if let Some(items_array) = items.as_array() {
+                                        for item in items_array {
+                                            if let Some(parent_id) =
+                                                item.get("parentID").and_then(|pid| pid.as_str())
+                                            {
+                                                if parent_id == container_id {
+                                                    if let Some(bookmark) =
+                                                        extract_bookmark_from_item_with_profile(
+                                                            item,
+                                                            &container_id,
+                                                            &profile_name,
+                                                        )
+                                                    {
+                                                        bookmarks.push(bookmark);
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(bookmarks)
+}
+
+/// Backward compatibility function
+pub fn extract_arc_bookmarks(arc_data: &Value) -> Result<Vec<ArcBookmark>> {
+    extract_arc_bookmarks_for_profile(arc_data, None)
+}
+
+/// Extracts bookmark from new JSON-LD format (no profile filtering)
+fn extract_bookmark_from_jsonld_item(item: &Value) -> Option<ArcBookmark> {
+    let item_type = item.get("@type")?.as_str()?;
+    if item_type != "know:Bookmark" {
+        return None;
+    }
+
+    let title = item.get("title")?.as_str()?.to_string();
+    let url = item.get("link")?.as_str()?.to_string();
+    let created_at = None;
+
+    Some(ArcBookmark {
+        title,
+        url,
+        created_at,
+    })
+}
+
+/// Extracts bookmark from sidebar item (legacy format)
+fn extract_bookmark_from_item(item: &Value, pinned_container_id: &str) -> Option<ArcBookmark> {
+    let parent_id = item.get("parentID")?.as_str()?;
+    if parent_id != pinned_container_id {
+        return None;
+    }
+
+    let data = item.get("data")?;
+    let tab = data.get("tab")?;
+
+    let saved_url = tab.get("savedURL")?.as_str()?.to_string();
+    let saved_title = tab.get("savedTitle")?.as_str()?.to_string();
+    let created_at = item.get("createdAt").and_then(|c| c.as_f64());
+
+    Some(ArcBookmark {
+        title: saved_title,
+        url: saved_url,
+        created_at,
+    })
+}
+
+/// Extracts bookmark from sidebar item (profile-based)
+fn extract_bookmark_from_item_with_profile(
+    item: &Value,
+    _container_id: &str,
+    _profile_name: &str,
+) -> Option<ArcBookmark> {
+    let data = item.get("data")?;
+    let tab = data.get("tab")?;
+
+    let saved_url = tab.get("savedURL")?.as_str()?.to_string();
+    let saved_title = tab.get("savedTitle")?.as_str()?.to_string();
+    let created_at = item.get("createdAt").and_then(|c| c.as_f64());
+
+    Some(ArcBookmark {
+        title: saved_title,
+        url: saved_url,
+        created_at,
+    })
+}
+
+/// Converts Arc bookmarks to Chromium format for browser import
+pub fn convert_arc_bookmarks_to_chromium(arc_data: Value, profile: Option<&str>) -> Result<Value> {
+    let bookmarks = extract_arc_bookmarks_for_profile(&arc_data, profile)?;
+    let mut counter = 0;
+    let mut chromium_bookmarks = Vec::new();
+
+    for bookmark in bookmarks {
+        counter += 1;
+
+        let date_added = if let Some(created_at) = bookmark.created_at {
+            convert_cf_absolute_time(created_at)
+        } else {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap();
+            ((now.as_secs() + 11644473600) * 1000000) as i64
+        };
+
+        let chromium_bookmark = serde_json::json!({
+            "guid": format!("arc-{}-{}", date_added, counter),
+            "name": bookmark.title,
+            "url": bookmark.url,
+            "type": "url",
+            "date_added": date_added,
+        });
+
+        chromium_bookmarks.push(chromium_bookmark);
+    }
+
+    let result = serde_json::json!({
+        "roots": {
+            "bookmark_bar": {
+                "children": chromium_bookmarks,
+                "type": "folder"
+            },
+            "other": {
+                "children": [],
+                "type": "folder"
+            }
+        }
+    });
+
+    Ok(result)
+}
+
+/// Converts Arc's CFAbsoluteTime to Chromium timestamp format
+pub fn convert_cf_absolute_time(cf_absolute_time: f64) -> i64 {
+    let seconds_between_1970_and_2001 = 978307200.0;
+    let unix_timestamp_seconds = cf_absolute_time + seconds_between_1970_and_2001;
+    ((unix_timestamp_seconds + 11644473600.0) * 1000000.0) as i64
+}

--- a/src/specialized/mod.rs
+++ b/src/specialized/mod.rs
@@ -1,0 +1,1 @@
+pub mod arc;


### PR DESCRIPTION
## **PR Description:**

### **What this PR does:**
- Adds Arc browser support to ASIMOV Chromium module
- Implements profile handling for Arc browser
- Supports both cataloger and reader tools

### **Current Limitation:**
- **Problem:** URLs with spaces don't work (e.g., `arc://bookmarks/Profile 1`)
- **Workaround:** Users must use format without spaces (e.g., `arc://bookmarks/Profile1`)
- **The tool automatically converts `Profile1` to `Profile 1` internally**

### **Question for the team:**
Should we:
1. **Keep current workaround** - Users use `Profile1` format (simple, works)
2. **Fix UriValueParser** - Allow spaces in URLs (more user-friendly, requires dependency changes)

### **How to test:**
- `arc://bookmarks/Profile1` - Works
- `arc://bookmarks/Default` - Works
- `arc://bookmarks/Profile 1` - Fails (UriValueParser limitation)

### **Evidence:**

**Default**
<img width="1089" height="781" alt="image" src="https://github.com/user-attachments/assets/fb9005e2-ac3f-44b8-b1fa-678c54cf7050" />

**Profile**
<img width="869" height="594" alt="image" src="https://github.com/user-attachments/assets/2062b36c-a1ce-4ed0-9375-0718dd5707a4" />