### PR TITLE
Enhance support for different profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,39 +40,49 @@ cargo install asimov-chromium-module
 
 ```bash
 asimov-chromium-cataloger chromium://bookmarks
-asimov-chromium-cataloger chromium://bookmarks/Profile\ 1
+asimov-chromium-cataloger chromium://bookmarks/1
+asimov-chromium-cataloger chromium://bookmarks/1
 ```
 
 #### Importing bookmarks from Chrome
 
 ```bash
-asimov-chromium-cataloger chrome://bookmarks
-asimov-chromium-cataloger chrome://bookmarks/Default
+asimov-chromium-cataloger chrome:
+asimov-chromium-cataloger chrome://bookmarks/1
+asimov-chromium-cataloger chrome://bookmarks/2 
 ```
 
 #### Importing bookmarks from Brave
 
 ```bash
 asimov-chromium-cataloger brave://bookmarks
-asimov-chromium-cataloger brave://bookmarks/Profile\ 2
+asimov-chromium-cataloger brave://bookmarks/1
+asimov-chromium-cataloger brave://bookmarks/2
 ```
 
 #### Importing bookmarks from Microsoft Edge
 
 ```bash
 asimov-chromium-cataloger edge://bookmarks
-asimov-chromium-cataloger edge://bookmarks/Profile\ 1
+asimov-chromium-cataloger edge://bookmarks/1
+asimov-chromium-cataloger edge://bookmarks/2
 ```
 
 #### Importing bookmarks from Arc
 
 ```bash
 asimov-chromium-cataloger arc://bookmarks
-asimov-chromium-cataloger arc://bookmarks/Default
-asimov-chromium-cataloger arc://bookmarks/Profile1
+asimov-chromium-cataloger arc://bookmarks/1
+asimov-chromium-cataloger arc://bookmarks/2
 ```
 
-**Note:** For Arc profiles with spaces, use the format without spaces (e.g., `Profile1` instead of `Profile 1`). The tool automatically formats them internally.
+**Note:**
+
+**Note:**
+
+- `{browser}://bookmarks` lists bookmarks from all available profiles
+- `{browser}://bookmarks/1` lists bookmarks from the first profile (Default)
+- `{browser}://bookmarks/2` lists bookmarks from the second profile
 
 ### Import of Bookmarks Files
 

--- a/README.md
+++ b/README.md
@@ -78,8 +78,6 @@ asimov-chromium-cataloger arc://bookmarks/2
 
 **Note:**
 
-**Note:**
-
 - `{browser}://bookmarks` lists bookmarks from all available profiles
 - `{browser}://bookmarks/1` lists bookmarks from the first profile (Default)
 - `{browser}://bookmarks/2` lists bookmarks from the second profile

--- a/src/bookmarks.rs
+++ b/src/bookmarks.rs
@@ -2,9 +2,6 @@
 
 use jq::{JsonFilter, JsonFilterError};
 use serde_json::Value;
-#[cfg(feature = "std")]
-use std::string::ToString;
-#[cfg(feature = "std")]
 use std::vec::Vec;
 
 /// Transforms Chromium JSON bookmarks to JSON-LD.
@@ -26,7 +23,31 @@ impl BookmarksTransform {
     /// Merges multiple bookmark profiles into a single result
     pub fn execute_multiple(&self, inputs: Vec<Value>) -> Result<Value, JsonFilterError> {
         if inputs.is_empty() {
-            return Ok(Value::Object(serde_json::Map::new()));
+            return Ok(serde_json::json!({
+                "@context": {
+                    "know": "https://know.dev/",
+                    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+                    "xsd": "http://www.w3.org/2001/XMLSchema#",
+                    "items": {
+                        "@id": "rdfs:member",
+                        "@type": "know:UserAccount",
+                        "@container": "@set"
+                    },
+                    "created": {
+                        "@id": "know:created",
+                        "@type": "xsd:dateTime"
+                    },
+                    "title": {
+                        "@id": "know:title",
+                        "@language": "en"
+                    },
+                    "link": {
+                        "@id": "know:link",
+                        "@type": "xsd:anyURI"
+                    }
+                },
+                "items": []
+            }));
         }
 
         if inputs.len() == 1 {

--- a/src/bookmarks.rs
+++ b/src/bookmarks.rs
@@ -1,5 +1,9 @@
 // This is free and unencumbered software released into the public domain.
 
+#[cfg(feature = "std")]
+use std::vec::Vec;
+#[cfg(feature = "std")]
+use std::string::ToString;
 use jq::{JsonFilter, JsonFilterError};
 use serde_json::Value;
 
@@ -17,5 +21,62 @@ impl BookmarksTransform {
 
     pub fn execute(&self, input: Value) -> Result<Value, JsonFilterError> {
         self.filter.filter_json(input)
+    }
+
+    /// Merges multiple bookmark profiles into a single result
+    pub fn execute_multiple(&self, inputs: Vec<Value>) -> Result<Value, JsonFilterError> {
+        if inputs.is_empty() {
+            return Ok(Value::Object(serde_json::Map::new()));
+        }
+
+        if inputs.len() == 1 {
+            return self.execute(inputs.into_iter().next().unwrap());
+        }
+
+        // Transform each profile individually and collect all items
+        let mut all_items = Vec::new();
+        
+        for input in &inputs {
+            // Use BookmarksTransform to convert to JSON-LD
+            let result = self.execute(input.clone())?;
+            
+            // Extract items from the result and add to all_items
+            if let Some(items) = result.get("items") {
+                if let Some(items_array) = items.as_array() {
+                    for item in items_array {
+                        all_items.push(item.clone());
+                    }
+                }
+            }
+        }
+        
+        // Create final merged result with all items from all profiles
+        let merged_result = serde_json::json!({
+            "@context": {
+                "know": "https://know.dev/",
+                "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+                "xsd": "http://www.w3.org/2001/XMLSchema#",
+                "items": {
+                    "@id": "rdfs:member",
+                    "@type": "know:UserAccount",
+                    "@container": "@set"
+                },
+                "created": {
+                    "@id": "know:created",
+                    "@type": "xsd:dateTime"
+                },
+                "title": {
+                    "@id": "know:title",
+                    "@language": "en"
+                },
+                "link": {
+                    "@id": "know:link",
+                    "@type": "xsd:anyURI"
+                }
+            },
+            "items": all_items
+        });
+        
+        Ok(merged_result)
     }
 }

--- a/src/bookmarks.rs
+++ b/src/bookmarks.rs
@@ -1,11 +1,11 @@
 // This is free and unencumbered software released into the public domain.
 
-#[cfg(feature = "std")]
-use std::vec::Vec;
-#[cfg(feature = "std")]
-use std::string::ToString;
 use jq::{JsonFilter, JsonFilterError};
 use serde_json::Value;
+#[cfg(feature = "std")]
+use std::string::ToString;
+#[cfg(feature = "std")]
+use std::vec::Vec;
 
 /// Transforms Chromium JSON bookmarks to JSON-LD.
 pub struct BookmarksTransform {
@@ -35,11 +35,11 @@ impl BookmarksTransform {
 
         // Transform each profile individually and collect all items
         let mut all_items = Vec::new();
-        
+
         for input in &inputs {
             // Use BookmarksTransform to convert to JSON-LD
             let result = self.execute(input.clone())?;
-            
+
             // Extract items from the result and add to all_items
             if let Some(items) = result.get("items") {
                 if let Some(items_array) = items.as_array() {
@@ -49,7 +49,7 @@ impl BookmarksTransform {
                 }
             }
         }
-        
+
         // Create final merged result with all items from all profiles
         let merged_result = serde_json::json!({
             "@context": {
@@ -76,7 +76,7 @@ impl BookmarksTransform {
             },
             "items": all_items
         });
-        
+
         Ok(merged_result)
     }
 }

--- a/src/browsers.rs
+++ b/src/browsers.rs
@@ -4,7 +4,7 @@ use serde_json::Value;
 use std::path::{Path, PathBuf};
 use std::string::{String, ToString};
 use std::vec::Vec;
-use std::{format, vec, eprintln};
+use std::{eprintln, format, vec};
 
 use crate::specialized;
 
@@ -318,7 +318,10 @@ pub fn fetch_bookmarks(url: &str) -> Result<Vec<Value>> {
                 if let Ok(path) = browser.bookmarks_path(Some(&profile_name)) {
                     eprintln!("DEBUG: Reading bookmarks from path: {}", path.display());
                     if let Ok(bookmarks) = read_bookmarks_file(&path, Some(&profile_name)) {
-                        eprintln!("DEBUG: Successfully read bookmarks for profile: {}", profile_name);
+                        eprintln!(
+                            "DEBUG: Successfully read bookmarks for profile: {}",
+                            profile_name
+                        );
                         outputs.push(bookmarks);
                     }
                 }

--- a/src/cataloger/main.rs
+++ b/src/cataloger/main.rs
@@ -78,7 +78,7 @@ pub fn main() -> Result<SysexitsError, Box<dyn Error>> {
         } else {
             transform.execute(input)?
         };
-        
+
         // Serialize the output JSON-LD:
         if cfg!(feature = "pretty") {
             colored_json::write_colored_json(&output, &mut std::io::stdout())?;

--- a/src/cataloger/main.rs
+++ b/src/cataloger/main.rs
@@ -70,11 +70,15 @@ pub fn main() -> Result<SysexitsError, Box<dyn Error>> {
     //     browsers::fetch_bookmarks(input_url)?
     // };
     let outputs = browsers::fetch_bookmarks(input_url.to_string().as_ref())?;
-
     // Transform JSON to JSON-LD:
     let transform = asimov_chromium_module::BookmarksTransform::new()?;
     for input in outputs {
-        let output = transform.execute(input)?;
+        let output = if input.get("@context").is_some() && input.get("items").is_some() {
+            input
+        } else {
+            transform.execute(input)?
+        };
+        
         // Serialize the output JSON-LD:
         if cfg!(feature = "pretty") {
             colored_json::write_colored_json(&output, &mut std::io::stdout())?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,5 +10,6 @@ pub mod bookmarks;
 pub mod browsers;
 pub mod jq;
 pub mod specialized;
+pub mod utils;
 
 pub use bookmarks::*;

--- a/src/specialized/arc.rs
+++ b/src/specialized/arc.rs
@@ -145,18 +145,18 @@ fn discover_profile_containers(arc_data: &Value) -> HashMap<String, String> {
 
 fn map_numeric_profile_to_name(arc_data: &Value, profile_index: u32) -> Option<String> {
     let profile_containers = discover_profile_containers(arc_data);
-    
+
     if profile_containers.is_empty() {
         return None;
     }
-    
+
     // Sort profile names to ensure consistent ordering
     let mut sorted_profiles: Vec<_> = profile_containers.keys().collect();
     sorted_profiles.sort();
-    
+
     // Convert 1-based index to 0-based array index
     let array_index = (profile_index as usize).saturating_sub(1);
-    
+
     if array_index < sorted_profiles.len() {
         Some(sorted_profiles[array_index].clone())
     } else {
@@ -196,7 +196,7 @@ pub fn extract_arc_bookmarks_for_numeric_profile(
         Some(0) | None => {
             // Return all bookmarks from all profiles
             extract_arc_bookmarks_for_profile(arc_data, None)
-        }
+        },
         Some(index) => {
             // Map numeric index to profile name
             if let Some(profile_name) = map_numeric_profile_to_name(arc_data, index) {
@@ -212,7 +212,7 @@ pub fn extract_arc_bookmarks_for_numeric_profile(
                         .join(", ")
                 ))
             }
-        }
+        },
     }
 }
 
@@ -434,7 +434,10 @@ pub fn convert_arc_bookmarks_to_chromium(arc_data: Value, profile: Option<&str>)
     Ok(result)
 }
 
-pub fn convert_arc_bookmarks_to_chromium_numeric(arc_data: Value, profile_index: Option<u32>) -> Result<Value> {
+pub fn convert_arc_bookmarks_to_chromium_numeric(
+    arc_data: Value,
+    profile_index: Option<u32>,
+) -> Result<Value> {
     let bookmarks = extract_arc_bookmarks_for_numeric_profile(&arc_data, profile_index)?;
     let mut counter = 0;
     let mut chromium_bookmarks = Vec::new();

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,0 +1,4 @@
+/// Utility functions for browser profile management
+pub mod profile;
+
+pub use profile::*;

--- a/src/utils/profile.rs
+++ b/src/utils/profile.rs
@@ -1,0 +1,17 @@
+/// Maps a 1-based profile index to the corresponding profile name
+///
+/// Profile indices are mapped to sorted profile names for consistent ordering.
+/// Index 1 maps to the first profile alphabetically, index 2 to the second, etc.
+pub fn map_numeric_profile_to_name(
+    available_profiles: &[std::string::String],
+    profile_index: u32,
+) -> Option<std::string::String> {
+    if profile_index == 0 || profile_index > available_profiles.len() as u32 {
+        return None;
+    }
+
+    let mut sorted_profiles = available_profiles.to_vec();
+    sorted_profiles.sort();
+
+    sorted_profiles.get((profile_index - 1) as usize).cloned()
+}


### PR DESCRIPTION
This PR simplifies profile selection by adding numeric profile support (e.g., `/1`, `/2`) and implements bookmark merging for multiple profiles.

### Changes
- Added numeric profile support: `brave://bookmarks/1`, `brave://bookmarks/2` instead of requiring full profile names
- Implemented `execute_multiple` method in `BookmarksTransform` to merge bookmarks from multiple profiles
- Refactored `fetch_bookmarks` to use the new merge functionality
- Simplified user experience by removing the need to specify exact profile names like `/Profile 1`

Now users can simply use numeric indices to access specific profiles, and when no index is specified (e.g., `brave://bookmarks`), all profiles are automatically merged into a single result.